### PR TITLE
Add optional opts for Flowex.Client.start

### DIFF
--- a/lib/flowex/client.ex
+++ b/lib/flowex/client.ex
@@ -3,8 +3,8 @@ defmodule Flowex.Client do
 
   use GenServer
 
-  def start(pipeline) do
-    GenServer.start_link(__MODULE__, pipeline)
+  def start(pipeline, opts \\ []) do
+    GenServer.start_link(__MODULE__, pipeline, opts)
   end
 
   def stop(pid) do


### PR DESCRIPTION
Add an ability to pass extra options to GenServer.start_link. For example, custom name.